### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/src/pages/api/audit.ts
+++ b/src/pages/api/audit.ts
@@ -6,7 +6,7 @@ const supabase = createClient(supabaseUrl, supabaseKey);
 
 const BOTSEE_API_KEY = process.env.BOTSEE_API_KEY;
 const BOTSEE_BASE_URL = 'https://www.botsee.io';
-
+const INTERNAL_BASE_URL = process.env.INTERNAL_BASE_URL || 'http://localhost:3000';
 function generateAccessCode() {
   return String(Math.floor(10000000 + Math.random() * 90000000));
 }
@@ -283,12 +283,12 @@ export default async function handler(req, res) {
           .eq('id', audit.id);
 
         if (telegram_handle) {
-          await fetch(`${req.headers.origin || 'http://localhost:3000'}/api/send-telegram`, {
+          await fetch(`${INTERNAL_BASE_URL}/api/send-telegram`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               telegram_handle,
-              message: `✅ Your AI Visibility Audit is ready!\n\n🔑 Access Code: ${accessCode}\n📊 View your report at: ${req.headers.origin || 'http://localhost:3000'}/audit/${accessCode}`,
+              message: `✅ Your AI Visibility Audit is ready!\n\n🔑 Access Code: ${accessCode}\n📊 View your report at: ${INTERNAL_BASE_URL}/audit/${accessCode}`,
             }),
           });
         }


### PR DESCRIPTION
Potential fix for [https://github.com/butterflyio/promptraise/security/code-scanning/1](https://github.com/butterflyio/promptraise/security/code-scanning/1)

In general, to fix this type of SSRF issue you should not construct the full request URL (including protocol/host) from user input. Instead, you should either: (1) use a fixed, server‑configured base URL and append only trusted paths, or (2) derive a *logical* identifier from user input and map it to a pre‑defined, allow‑listed base URL. User-controlled data should never control the hostname or protocol of a server-side `fetch` call.

For this specific case, the backend should not rely on `req.headers.origin` to determine where to call `/api/send-telegram`. Since this endpoint is part of the same Next.js application, the safest and simplest change is to use a fixed, server-side base URL (for example from an environment variable such as `NEXTAUTH_URL` or a new dedicated env var like `INTERNAL_BASE_URL`), or to call it via a relative path that is resolved against a trusted base. Because we must not assume other code or env vars, the least invasive change that removes user control is to replace `${req.headers.origin || 'http://localhost:3000'}` with a server-side configured base URL constant defined in this file and sourced from the environment (falling back to `http://localhost:3000` only as a *server-configured* default, not from the request). This preserves behavior (still calling the same route) while breaking the taint flow from the request.

Concretely:
- Introduce a new constant near the top of `src/pages/api/audit.ts`, e.g. `const INTERNAL_BASE_URL = process.env.INTERNAL_BASE_URL || 'http://localhost:3000';`.
- Replace both uses of `req.headers.origin || 'http://localhost:3000'` in the Telegram-related code with `INTERNAL_BASE_URL`.
- This ensures the outgoing `fetch` always uses a server-chosen base URL and cannot be redirected by manipulating the `Origin` header, while preserving the current semantics (local default base URL unless overridden by configuration).

No new imports are needed; we only add a constant and adjust the string interpolation for the `fetch` call and the message URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
